### PR TITLE
feat(netmask): add validator `IsValidNetmask`

### DIFF
--- a/stringvalidator/valid_netmask.go
+++ b/stringvalidator/valid_netmask.go
@@ -1,0 +1,53 @@
+package stringvalidator
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+var _ validator.String = netmaskValidator{}
+
+type netmaskValidator struct {
+}
+
+// Description describes the validation in plain text formatting.
+func (validator netmaskValidator) Description(_ context.Context) string {
+	return "must be a valid netmask"
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (validator netmaskValidator) MarkdownDescription(ctx context.Context) string {
+	return validator.Description(ctx)
+}
+
+// Validate performs the validation.
+func (validator netmaskValidator) ValidateString(
+	ctx context.Context,
+	request validator.StringRequest,
+	response *validator.StringResponse,
+) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	var re = regexp.MustCompile(`(?m)^(((255\.){3}(255|254|252|248|240|224|192|128|0+))|((255\.){2}(255|254|252|248|240|224|192|128|0+)\.0)|((255\.)(255|254|252|248|240|224|192|128|0+)(\.0+){2})|((255|254|252|248|240|224|192|128|0+)(\.0+){3}))$`)
+
+	if !re.MatchString(request.ConfigValue.ValueString()) {
+		response.Diagnostics.AddAttributeError(
+			request.Path,
+			"Failed to parse netmask",
+			fmt.Sprintf("invalid value: %s", request.ConfigValue.String()),
+		)
+	}
+
+}
+
+// IsValidNetmask returns a validator which ensures that the configured attribute
+// value is a valid Netmask.
+// Null (unconfigured) and unknown (known after apply) values are skipped.
+func IsValidNetmask() validator.String {
+	return &netmaskValidator{}
+}

--- a/stringvalidator/valid_netmask_test.go
+++ b/stringvalidator/valid_netmask_test.go
@@ -1,0 +1,59 @@
+package stringvalidator_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/FrangipaneTeam/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestValidNetmaskValidator(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		val         types.String
+		expectError bool
+	}
+	tests := map[string]testCase{
+		"unknown": {
+			val: types.StringUnknown(),
+		},
+		"null": {
+			val: types.StringNull(),
+		},
+		"valid": {
+			val: types.StringValue("255.255.255.0"),
+		},
+		"invalid": {
+			val:         types.StringValue("254.255.255.0"),
+			expectError: true,
+		},
+		"multiple byte characters": {
+			// Rightwards Arrow Over Leftwards Arrow (U+21C4; 3 bytes)
+			val:         types.StringValue("⇄"),
+			expectError: true,
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			request := validator.StringRequest{
+				ConfigValue: test.val,
+			}
+			response := validator.StringResponse{}
+			stringvalidator.IsValidNetmask().ValidateString(context.TODO(), request, &response)
+
+			if !response.Diagnostics.HasError() && test.expectError {
+				t.Fatal("expected error, got no error")
+			}
+
+			if response.Diagnostics.HasError() && !test.expectError {
+				t.Fatalf("got unexpected error: %s", response.Diagnostics)
+			}
+		})
+	}
+}


### PR DESCRIPTION
```
Running tool: /opt/homebrew/bin/go test -timeout 30s -run ^TestValidNetmaskValidator$ github.com/FrangipaneTeam/terraform-plugin-framework-validators/stringvalidator

ok  	github.com/FrangipaneTeam/terraform-plugin-framework-validators/stringvalidator	0.337s
```