### PR TITLE
feat: add `IsValidURN` string validator 

### DIFF
--- a/docs/stringvalidator/index.md
+++ b/docs/stringvalidator/index.md
@@ -17,3 +17,7 @@ import (
 
 - [`IsValidIP`](isvalidip.md) - This validator is used to check if the string is a valid IP address.
 - [`IsValidNetmask`](isvalidnetmask.md) - This validator is used to check if the string is a valid netmask.
+
+## String
+
+- [`IsValidURN`](isvalidurn.md) - This validator is used to check if the string is a valid URN.

--- a/docs/stringvalidator/isvalidurn.md
+++ b/docs/stringvalidator/isvalidurn.md
@@ -1,0 +1,19 @@
+# `IsValidURN`
+
+This validator is used to check if the string is a valid URN.
+
+## How to use it
+
+```go
+// Schema defines the schema for the resource.
+func (r *xResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+    resp.Schema = schema.Schema{
+        (...)
+            "vm_id": schema.StringAttribute{
+                Optional:            true,
+                MarkdownDescription: "The VM ID for ...",
+                Validators: []validator.String{
+                    fstringvalidator.IsValidURN()
+                },
+            },
+```

--- a/stringvalidator/valid_ip.go
+++ b/stringvalidator/valid_ip.go
@@ -10,8 +10,7 @@ import (
 
 var _ validator.String = netIPValidator{}
 
-type netIPValidator struct {
-}
+type netIPValidator struct{}
 
 // Description describes the validation in plain text formatting.
 func (validator netIPValidator) Description(_ context.Context) string {

--- a/stringvalidator/valid_netmask.go
+++ b/stringvalidator/valid_netmask.go
@@ -10,8 +10,7 @@ import (
 
 var _ validator.String = netmaskValidator{}
 
-type netmaskValidator struct {
-}
+type netmaskValidator struct{}
 
 // Description describes the validation in plain text formatting.
 func (validator netmaskValidator) Description(_ context.Context) string {
@@ -33,7 +32,7 @@ func (validator netmaskValidator) ValidateString(
 		return
 	}
 
-	var re = regexp.MustCompile(`(?m)^(((255\.){3}(255|254|252|248|240|224|192|128|0+))|((255\.){2}(255|254|252|248|240|224|192|128|0+)\.0)|((255\.)(255|254|252|248|240|224|192|128|0+)(\.0+){2})|((255|254|252|248|240|224|192|128|0+)(\.0+){3}))$`)
+	re := regexp.MustCompile(`(?m)^(((255\.){3}(255|254|252|248|240|224|192|128|0+))|((255\.){2}(255|254|252|248|240|224|192|128|0+)\.0)|((255\.)(255|254|252|248|240|224|192|128|0+)(\.0+){2})|((255|254|252|248|240|224|192|128|0+)(\.0+){3}))$`)
 
 	if !re.MatchString(request.ConfigValue.ValueString()) {
 		response.Diagnostics.AddAttributeError(
@@ -42,7 +41,6 @@ func (validator netmaskValidator) ValidateString(
 			fmt.Sprintf("invalid value: %s", request.ConfigValue.String()),
 		)
 	}
-
 }
 
 // IsValidNetmask returns a validator which ensures that the configured attribute

--- a/stringvalidator/valid_netmask_test.go
+++ b/stringvalidator/valid_netmask_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/FrangipaneTeam/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/FrangipaneTeam/terraform-plugin-framework-validators/stringvalidator"
 )
 
 func TestValidNetmaskValidator(t *testing.T) {

--- a/stringvalidator/valid_urn.go
+++ b/stringvalidator/valid_urn.go
@@ -1,0 +1,50 @@
+package stringvalidator
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+var _ validator.String = urnValidator{}
+
+type urnValidator struct{}
+
+// Description describes the validation in plain text formatting.
+func (validator urnValidator) Description(_ context.Context) string {
+	return "must be a valid URN"
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (validator urnValidator) MarkdownDescription(ctx context.Context) string {
+	return validator.Description(ctx)
+}
+
+// Validate performs the validation.
+func (validator urnValidator) ValidateString(
+	ctx context.Context,
+	request validator.StringRequest,
+	response *validator.StringResponse,
+) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	re := regexp.MustCompile(`(?m)urn:[A-Za-z0-9][A-Za-z0-9-]{0,31}:([A-Za-z0-9()+,\-.:=@;$_!*']|%[0-9A-Fa-f]{2})+`)
+
+	if !re.MatchString(request.ConfigValue.ValueString()) {
+		response.Diagnostics.AddAttributeError(
+			request.Path,
+			"Failed to parse URN",
+			fmt.Sprintf("invalid URN: %s", request.ConfigValue.String()),
+		)
+	}
+}
+
+// IsValidURN returns a validator which ensures that the configured attribute
+// Null (unconfigured) and unknown (known after apply) values are skipped.
+func IsValidURN() validator.String {
+	return &urnValidator{}
+}

--- a/stringvalidator/valid_urn_test.go
+++ b/stringvalidator/valid_urn_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/FrangipaneTeam/terraform-plugin-framework-validators/stringvalidator"
 )
 
-func TestValidIPValidator(t *testing.T) {
+func TestValidURNValidator(t *testing.T) {
 	t.Parallel()
 
 	type testCase struct {
@@ -25,10 +25,10 @@ func TestValidIPValidator(t *testing.T) {
 			val: types.StringNull(),
 		},
 		"valid": {
-			val: types.StringValue("192.168.1.1"),
+			val: types.StringValue("urn:test:demo:4aeb40d8-038c-4e77-8181-a7054f583b12"),
 		},
 		"invalid": {
-			val:         types.StringValue("192.168.1"),
+			val:         types.StringValue("4aeb40d8-038c-4e77-8181-a7054f583b12"),
 			expectError: true,
 		},
 		"multiple byte characters": {
@@ -46,7 +46,7 @@ func TestValidIPValidator(t *testing.T) {
 				ConfigValue: test.val,
 			}
 			response := validator.StringResponse{}
-			stringvalidator.IsValidIP().ValidateString(context.TODO(), request, &response)
+			stringvalidator.IsValidURN().ValidateString(context.TODO(), request, &response)
 
 			if !response.Diagnostics.HasError() && test.expectError {
 				t.Fatal("expected error, got no error")


### PR DESCRIPTION
This validator is used to check if the string is a valid URN.

```
go test -timeout 30s -run ^TestValidURNValidator$ github.com/FrangipaneTeam/terraform-plugin-framework-validators/stringvalidator

ok  	github.com/FrangipaneTeam/terraform-plugin-framework-validators/stringvalidator   0.523s
```