### PR TITLE
feat: Add `IsMacAddress` String validator

### DIFF
--- a/stringvalidator/network_mac_address.go
+++ b/stringvalidator/network_mac_address.go
@@ -1,0 +1,24 @@
+package stringvalidator
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/FrangipaneTeam/terraform-plugin-framework-validators/stringvalidator/common"
+)
+
+/*
+IsMacAddress
+
+returns a validator which ensures that the configured attribute
+value is a valid MacAddress.
+
+Null (unconfigured) and unknown (known after apply) values are skipped.
+*/
+func IsMacAddress() validator.String {
+	return &common.RegexValidator{
+		Desc:         "must be a valid mac address",
+		Regex:        `(?m)^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$`,
+		ErrorSummary: "Failed to parse mac address",
+		ErrorDetail:  "This value is not a valid mac address",
+	}
+}

--- a/stringvalidator/network_mac_address_test.go
+++ b/stringvalidator/network_mac_address_test.go
@@ -1,0 +1,60 @@
+package stringvalidator_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/FrangipaneTeam/terraform-plugin-framework-validators/stringvalidator"
+)
+
+func TestNetworkMacAddressValidator(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		val         types.String
+		expectError bool
+	}
+	tests := map[string]testCase{
+		"unknown": {
+			val: types.StringUnknown(),
+		},
+		"null": {
+			val: types.StringNull(),
+		},
+		"valid": {
+			val: types.StringValue("5E:FF:56:A2:AF:15"),
+		},
+		"invalid": {
+			val:         types.StringValue("5E:FF:56:A2:AF"),
+			expectError: true,
+		},
+		"multiple byte characters": {
+			// Rightwards Arrow Over Leftwards Arrow (U+21C4; 3 bytes)
+			val:         types.StringValue("⇄"),
+			expectError: true,
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			request := validator.StringRequest{
+				ConfigValue: test.val,
+			}
+			response := validator.StringResponse{}
+			stringvalidator.IsMacAddress().ValidateString(context.TODO(), request, &response)
+
+			if !response.Diagnostics.HasError() && test.expectError {
+				t.Fatal("expected error, got no error")
+			}
+
+			if response.Diagnostics.HasError() && !test.expectError {
+				t.Fatalf("got unexpected error: %s", response.Diagnostics)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Result of test: 

```
go test -timeout 30s -run ^TestNetworkMacAddressValidator$ github.com/FrangipaneTeam/terraform-plugin-framework-validators/stringvalidator

ok  	github.com/FrangipaneTeam/terraform-plugin-framework-validators/stringvalidator	0,201s
```