### PR TITLE
fix: Missing documentation for `IsMacAddress` string validator (#35)

### DIFF
--- a/docs/stringvalidator/index.md
+++ b/docs/stringvalidator/index.md
@@ -17,6 +17,7 @@ import (
 
 - [`IsIP`](isip.md) - This validator is used to check if the string is a valid IP address.
 - [`IsNetmask`](isnetmask.md) - This validator is used to check if the string is a valid netmask.
+- [`IsMacAddress`](ismacaddress.md) - This validator is used to check if the string is a valid MAC address.
 
 ## String
 

--- a/docs/stringvalidator/ismacaddress.md
+++ b/docs/stringvalidator/ismacaddress.md
@@ -1,0 +1,21 @@
+# `IsMacAddress`
+
+!!! quote inline end "Released in v1.2.0"
+
+This validator is used to check if the string is a valid Mac Address.
+
+## How to use it
+
+```go
+// Schema defines the schema for the resource.
+func (r *xResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+    resp.Schema = schema.Schema{
+        (...)
+            "mac_address": schema.StringAttribute{
+                Optional:            true,
+                MarkdownDescription: "Mac Adresse for ...",
+                Validators: []validator.String{
+                    fstringvalidator.IsMacAddress()
+                },
+            },
+```


### PR DESCRIPTION
fix #35