### PR TITLE
feat: add `stringvalidator/PrefixContains`

### DIFF
--- a/.changelog/76.txt
+++ b/.changelog/76.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+`stringvalidator/PrefixContains` - Check if the string contains the prefix.
+```

--- a/.vscode/terraform.code-snippets
+++ b/.vscode/terraform.code-snippets
@@ -1,0 +1,119 @@
+{
+	"Release Note Breaking change": {
+		"scope": "plaintext",
+		"prefix": "release-note-breaking-change",
+		"body": [
+			"```release-note:breaking-change",
+			"`resource/cloudavenue_xx` - Short Description.",
+			"`datasource/cloudavenue_xx` - Short Description.",
+			"```"
+		]
+	},
+	"Release Note New stringvalidator": {
+		"scope": "plaintext",
+		"prefix": "release-note-new-stringvalidator",
+		"body": [
+			"```release-note:feature",
+			"`stringvalidator/xxx` - Short Description.",
+			"```"
+		]
+	},
+	"Release Note New boolvalidator": {
+		"scope": "plaintext",
+		"prefix": "release-note-new-boolvalidator",
+		"body": [
+			"```release-note:feature",
+			"`boolvalidator/xxx` - Short Description.",
+			"```"
+		]
+	},
+	"Release Note New int64validator": {
+		"scope": "plaintext",
+		"prefix": "release-note-new-intvalidator",
+		"body": [
+			"```release-note:feature",
+			"`intvalidator/xxx` - Short Description.",
+			"```"
+		]
+	},
+	"Release Note New float64validator": {
+		"scope": "plaintext",
+		"prefix": "release-note-new-floatvalidator",
+		"body": [
+			"```release-note:feature",
+			"`floatvalidator/xxx` - Short Description.",
+			"```"
+		]
+	},
+	"Release Note New listvalidator": {
+		"scope": "plaintext",
+		"prefix": "release-note-new-listvalidator",
+		"body": [
+			"```release-note:feature",
+			"`listvalidator/xxx` - Short Description.",
+			"```"
+		]
+	},
+	"Release Note New mapvalidator": {
+		"scope": "plaintext",
+		"prefix": "release-note-new-mapvalidator",
+		"body": [
+			"```release-note:feature",
+			"`mapvalidator/xxx` - Short Description.",
+			"```"
+		]
+	},
+	"Release Note New setvalidator": {
+		"scope": "plaintext",
+		"prefix": "release-note-new-setvalidator",
+		"body": [
+			"```release-note:feature",
+			"`setvalidator/xxx` - Short Description.",
+			"```"
+		]
+	},
+	// Release note feature
+	"Release Note New Feature": {
+		"scope": "plaintext",
+		"prefix": "release-note-feature",
+		"body": [
+			"```release-note:feature",
+			"`resource/cloudavenue_xx` - Short Description.",
+			"`datasource/cloudavenue_xx` - Short Description.",
+			"```"
+		]
+	},
+	// Release note bug
+	"Release Note Bug": {
+		"scope": "plaintext",
+		"prefix": "release-note-bug",
+		"body": [
+			"```release-note:bug",
+			"`resource/cloudavenue_xx` - Short Description.",
+			"`datasource/cloudavenue_xx` - Short Description.",
+			"```"
+		]
+	},
+	// Release note Note
+	"Release Note Note": {
+		"scope": "plaintext",
+		"prefix": "release-note-note",
+		"body": [
+			"```release-note:note",
+			"`resource/cloudavenue_xx` - Short Description.",
+			"`datasource/cloudavenue_xx` - Short Description.",
+			"```"
+		]
+	},
+	// Release note enchancement
+	"Release Note Enhancement": {
+		"scope": "plaintext",
+		"prefix": "release-note-enhancement",
+		"body": [
+			"```release-note:enhancement",
+			"`resource/cloudavenue_xx` - Short Description.",
+			"`datasource/cloudavenue_xx` - Short Description.",
+			"```"
+		]
+	},
+}

--- a/docs/stringvalidator/index.md
+++ b/docs/stringvalidator/index.md
@@ -27,6 +27,7 @@ import (
 
 - [`IsURN`](isurn.md) - This validator is used to check if the string is a valid URN.
 - [`IsUUID`](isuuid.md) - This validator is used to check if the string is a valid UUID.
+- [`PrefixContains`](prefixcontains.md) - This validator is used to check if the string contains prefix in the given value.
 
 ### Special
 

--- a/docs/stringvalidator/prefixcontains.md
+++ b/docs/stringvalidator/prefixcontains.md
@@ -1,0 +1,28 @@
+# `PrefixContains`
+
+!!! quote inline end "Released in v1.7.0"
+
+This validator is used to check if the string contains prefix in the given value.
+
+## How to use it
+
+```go
+// Schema defines the schema for the resource.
+func (r *xResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+    resp.Schema = schema.Schema{
+        (...)
+            "interface_type": schema.StringAttribute{
+                Optional:            true,
+                MarkdownDescription: "Type of ...",
+                Validators: []validator.String{
+                    fstringvalidator.PrefixContains("urn:test:demo:")
+                },
+            },
+```
+
+## Description and Markdown description
+
+* **Description:**
+must start with "urn:test:demo:"
+* **Markdown description:**
+This value must start with `urn:test:demo:`.

--- a/stringvalidator/common/valid_with_prefix.go
+++ b/stringvalidator/common/valid_with_prefix.go
@@ -1,0 +1,40 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+var _ validator.String = PrefixValidator{}
+
+type PrefixValidator struct {
+	Prefix string
+}
+
+// Description describes the validation in plain text formatting.
+func (validator PrefixValidator) Description(_ context.Context) string {
+	return fmt.Sprintf("must start with \"%s\"", validator.Prefix)
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (validator PrefixValidator) MarkdownDescription(_ context.Context) string {
+	return fmt.Sprintf("This value must start with `%s`.", validator.Prefix)
+}
+
+// Validate performs the validation.
+func (validator PrefixValidator) ValidateString(_ context.Context, request validator.StringRequest, response *validator.StringResponse) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	if !strings.HasPrefix(request.ConfigValue.ValueString(), validator.Prefix) {
+		response.Diagnostics.AddAttributeError(
+			request.Path,
+			"Does not start with prefix",
+			fmt.Sprintf("The value %s does not start with the prefix \"%s\".", request.ConfigValue.String(), validator.Prefix),
+		)
+	}
+}

--- a/stringvalidator/prefix.go
+++ b/stringvalidator/prefix.go
@@ -1,0 +1,17 @@
+package stringvalidator
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/FrangipaneTeam/terraform-plugin-framework-validators/stringvalidator/common"
+)
+
+// PrefixContainsValidator is a validator which ensures that the configured attribute
+// value contains the specified prefix.
+//
+// Null (unconfigured) and unknown (known after apply) values are skipped.
+func PrefixContains(prefix string) validator.String {
+	return &common.PrefixValidator{
+		Prefix: prefix,
+	}
+}

--- a/stringvalidator/prefix_test.go
+++ b/stringvalidator/prefix_test.go
@@ -1,0 +1,60 @@
+package stringvalidator_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/FrangipaneTeam/terraform-plugin-framework-validators/stringvalidator"
+)
+
+func TestPrefixContainsValidator(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		val         types.String
+		expectError bool
+	}
+	tests := map[string]testCase{
+		"unknown": {
+			val: types.StringUnknown(),
+		},
+		"null": {
+			val: types.StringNull(),
+		},
+		"valid": {
+			val: types.StringValue("urn:test:demo:4aeb40d8-038c-4e77-8181-a7054f583b12"),
+		},
+		"invalid": {
+			val:         types.StringValue("4aeb40d8-038c-4e77-8181-a7054f583b12"),
+			expectError: true,
+		},
+		"multiple byte characters": {
+			// Rightwards Arrow Over Leftwards Arrow (U+21C4; 3 bytes)
+			val:         types.StringValue("⇄"),
+			expectError: true,
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			request := validator.StringRequest{
+				ConfigValue: test.val,
+			}
+			response := validator.StringResponse{}
+			stringvalidator.PrefixContains("urn:test:demo:").ValidateString(context.TODO(), request, &response)
+
+			if !response.Diagnostics.HasError() && test.expectError {
+				t.Fatal("expected error, got no error")
+			}
+
+			if response.Diagnostics.HasError() && !test.expectError {
+				t.Fatalf("got unexpected error: %s", response.Diagnostics)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add new stringvalidator for checking if string contains the prefix. 

```
go test -timeout 30s -run ^TestPrefixContainsValidator$ github.com/FrangipaneTeam/terraform-plugin-framework-validators/stringvalidator

ok  	github.com/FrangipaneTeam/terraform-plugin-framework-validators/stringvalidator	(cached)
```