### PR TITLE
feat: add generic validator `NullIfAttributeIsSet`

### DIFF
--- a/.changelog/83.txt
+++ b/.changelog/83.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+`NullIfAttributeIsSet` - New validator that allows you to validate that a attribute is null if another attribute is set. This is available for all types of attributes.
+```

--- a/.changelog/83.txt
+++ b/.changelog/83.txt
@@ -1,3 +1,3 @@
 ```release-note:feature
-`NullIfAttributeIsSet` - New validator that allows you to validate that a attribute is null if another attribute is set. This is available for all types of attributes.
+`NullIfAttributeIsSet` - New validator that allows you to validate that an attribute is null if another attribute is set. This is available for all types of attributes.
 ```

--- a/boolvalidator/null_if_attribute_is_set.go
+++ b/boolvalidator/null_if_attribute_is_set.go
@@ -1,0 +1,16 @@
+package boolvalidator
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/FrangipaneTeam/terraform-plugin-framework-validators/internal"
+)
+
+// NullIfAttributeIsSet checks if the path.Path attribute contains
+// one of the exceptedValue attr.Value.
+func NullIfAttributeIsSet(path path.Expression) validator.Bool {
+	return internal.NullIfAttributeIsSet{
+		PathExpression: path,
+	}
+}

--- a/docs/boolvalidator/index.md
+++ b/docs/boolvalidator/index.md
@@ -15,6 +15,7 @@ import (
 
 - [`RequireIfAttributeIsOneOf`](../common/require_if_attribute_is_one_of.md) - This validator is used to require the attribute if another attribute is one of the given values.
 - [`NullIfAttributeIsOneOf`](../common/null_if_attribute_is_one_of.md) - This validator is used to verify the attribute value is null if another attribute is one of the given values.
+- [`NullIfAttributeIsSet`](../common/null_if_attribute_is_set.md) - This validator is used to verify the attribute value is null if another attribute is set.
 
 ## Special
 

--- a/docs/common/null_if_attribute_is_set.md
+++ b/docs/common/null_if_attribute_is_set.md
@@ -1,8 +1,9 @@
-# `NullIfAttributeIsOneOf`
+# `NullIfAttributeIsSet`
 
-!!! quote inline end "Released in v1.6.0"
+!!! quote inline end "Released in v1.8.0"
 
-This validator is used to verify the attribute value is null if another attribute is one of the given values.
+This validator is used to verify the attribute value is null if another attribute is set.
+Set could mean either the attribute is present in the configuration.
 
 ## How to use it
 
@@ -22,11 +23,11 @@ func (r *xResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *
                 Optional:            true,
                 MarkdownDescription: "Enable ...",
                 Validators: []validator.Bool{
-                    fboolvalidator.NullIfAttributeIsOneOf(path.MatchRoot("network_type"),[]attr.Value{types.StringValue("private")})
+                    fboolvalidator.NullIfAttributeIsSet(path.MatchRoot("network_type"))
                 },
             },
 ```
 
 ## Example of generated documentation
 
-If the value of [`network_type`](#network_type) attribute is `private` this attribute is **NULL**.
+If the value of [`network_type`](#network_type) attribute is set this attribute is **NULL**.

--- a/docs/int64validator/index.md
+++ b/docs/int64validator/index.md
@@ -15,6 +15,7 @@ import (
 
 - [`RequireIfAttributeIsOneOf`](../common/require_if_attribute_is_one_of.md) - This validator is used to require the attribute if another attribute is one of the given values.
 - [`NullIfAttributeIsOneOf`](../common/null_if_attribute_is_one_of.md) - This validator is used to verify the attribute value is null if another attribute is one of the given values.
+- [`NullIfAttributeIsSet`](../common/null_if_attribute_is_set.md) - This validator is used to verify the attribute value is null if another attribute is set.
 - [`OneOfWithDescription`](oneofwithdescription.md) - This validator is used to check if the string is one of the given values and format the description and the markdown description.
 - [`AttributeIsDivisibleByAnInteger`](attribute_is_divisible_by_an_integer.md) - This validator is used to validate that the attribute is divisible by an integer.
 - [`ZeroRemainder`](zero_remainder.md) - This validator checks if the configured attribute is divisible by a specified integer X, and has zero remainder.

--- a/docs/listvalidator/index.md
+++ b/docs/listvalidator/index.md
@@ -17,6 +17,7 @@ Every `string` validators are available for maps thanks to a generic validator p
 
 - [`RequireIfAttributeIsOneOf`](../common/require_if_attribute_is_one_of.md) - This validator is used to require the attribute if another attribute is one of the given values.
 - [`NullIfAttributeIsOneOf`](../common/null_if_attribute_is_one_of.md) - This validator is used to verify the attribute value is null if another attribute is one of the given values.
+- [`NullIfAttributeIsSet`](../common/null_if_attribute_is_set.md) - This validator is used to verify the attribute value is null if another attribute is set.
 
 ## Special
 

--- a/docs/mapvalidator/index.md
+++ b/docs/mapvalidator/index.md
@@ -17,6 +17,7 @@ Every `string` validators are available for maps thanks to a generic validator p
 
 - [`RequireIfAttributeIsOneOf`](../common/require_if_attribute_is_one_of.md) - This validator is used to require the attribute if another attribute is one of the given values.
 - [`NullIfAttributeIsOneOf`](../common/null_if_attribute_is_one_of.md) - This validator is used to verify the attribute value is null if another attribute is one of the given values.
+- [`NullIfAttributeIsSet`](../common/null_if_attribute_is_set.md) - This validator is used to verify the attribute value is null if another attribute is set.
 
 ## Special
 

--- a/docs/setvalidator/index.md
+++ b/docs/setvalidator/index.md
@@ -17,6 +17,7 @@ Every `string` validators are available for maps thanks to a generic validator p
 
 - [`RequireIfAttributeIsOneOf`](../common/require_if_attribute_is_one_of.md) - This validator is used to require the attribute if another attribute is one of the given values.
 - [`NullIfAttributeIsOneOf`](../common/null_if_attribute_is_one_of.md) - This validator is used to verify the attribute value is null if another attribute is one of the given values.
+- [`NullIfAttributeIsSet`](../common/null_if_attribute_is_set.md) - This validator is used to verify the attribute value is null if another attribute is set.
 
 ### Special
 

--- a/docs/stringvalidator/index.md
+++ b/docs/stringvalidator/index.md
@@ -15,6 +15,7 @@ import (
 
 - [`RequireIfAttributeIsOneOf`](../common/require_if_attribute_is_one_of.md) - This validator is used to require the attribute if another attribute is one of the given values.
 - [`NullIfAttributeIsOneOf`](../common/null_if_attribute_is_one_of.md) - This validator is used to verify the attribute value is null if another attribute is one of the given values.
+- [`NullIfAttributeIsSet`](../common/null_if_attribute_is_set.md) - This validator is used to verify the attribute value is null if another attribute is set.
 - [`OneOfWithDescription`](oneofwithdescription.md) - This validator is used to check if the string is one of the given values and format the description and the markdown description.
 
 ### Network

--- a/int64validator/null_if_attribute_is_set.go
+++ b/int64validator/null_if_attribute_is_set.go
@@ -1,0 +1,16 @@
+package int64validator
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/FrangipaneTeam/terraform-plugin-framework-validators/internal"
+)
+
+// NullIfAttributeIsSet checks if the path.Path attribute contains
+// one of the exceptedValue attr.Value.
+func NullIfAttributeIsSet(path path.Expression) validator.Int64 {
+	return internal.NullIfAttributeIsSet{
+		PathExpression: path,
+	}
+}

--- a/internal/null_if_attribute_is_set.go
+++ b/internal/null_if_attribute_is_set.go
@@ -1,0 +1,223 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+)
+
+// This type of validator must satisfy all types.
+var (
+	_ validator.Bool    = NullIfAttributeIsSet{}
+	_ validator.Float64 = NullIfAttributeIsSet{}
+	_ validator.Int64   = NullIfAttributeIsSet{}
+	_ validator.List    = NullIfAttributeIsSet{}
+	_ validator.Map     = NullIfAttributeIsSet{}
+	_ validator.Number  = NullIfAttributeIsSet{}
+	_ validator.Object  = NullIfAttributeIsSet{}
+	_ validator.Set     = NullIfAttributeIsSet{}
+	_ validator.String  = NullIfAttributeIsSet{}
+)
+
+// NullIfAttributeIsSet is the underlying struct implementing AlsoRequires.
+type NullIfAttributeIsSet struct {
+	PathExpression path.Expression
+}
+
+type NullIfAttributeIsSetRequest struct {
+	Config         tfsdk.Config
+	ConfigValue    attr.Value
+	Path           path.Path
+	PathExpression path.Expression
+}
+
+type NullIfAttributeIsSetResponse struct {
+	Diagnostics diag.Diagnostics
+}
+
+func (av NullIfAttributeIsSet) Description(_ context.Context) string {
+	return fmt.Sprintf("If %s attribute is set this attribute is NULL", av.PathExpression)
+}
+
+func (av NullIfAttributeIsSet) MarkdownDescription(_ context.Context) string {
+	return fmt.Sprintf("If the [`%s`](#%s) attribute is set this attribute is **NULL**", av.PathExpression, av.PathExpression)
+}
+
+func (av NullIfAttributeIsSet) Validate(ctx context.Context, req NullIfAttributeIsSetRequest, res *NullIfAttributeIsSetResponse) {
+	var diags diag.Diagnostics
+
+	// If attribute configuration is null, there is nothing else to validate
+	if req.ConfigValue.IsNull() {
+		return
+	}
+
+	// Here attribute configuration is null or unknown, so we need to check if attribute in the path
+	// is equal to one of the excepted values
+	paths, diags := req.Config.PathMatches(ctx, req.PathExpression.Merge(av.PathExpression))
+	res.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return
+	}
+
+	if len(paths) == 0 {
+		res.Diagnostics.AddError(
+			fmt.Sprintf("Invalid configuration for attribute %s", req.Path),
+			"Path must be set",
+		)
+		return
+	}
+
+	for _, path := range paths {
+		var mpVal attr.Value
+		diags = req.Config.GetAttribute(ctx, path, &mpVal)
+		if diags.HasError() {
+			res.Diagnostics.AddError(
+				fmt.Sprintf("Invalid configuration for attribute %s", req.Path),
+				fmt.Sprintf("Unable to retrieve attribute path: %q", path),
+			)
+			return
+		}
+
+		// if the attribute is null, we don't need to check the value
+		if mpVal.IsNull() {
+			return
+		}
+
+		res.Diagnostics.AddAttributeError(
+			path,
+			fmt.Sprintf("Invalid configuration for attribute %s", req.Path),
+			av.Description(ctx),
+		)
+	}
+}
+
+func (av NullIfAttributeIsSet) ValidateBool(ctx context.Context, req validator.BoolRequest, resp *validator.BoolResponse) {
+	validateReq := NullIfAttributeIsSetRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &NullIfAttributeIsSetResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av NullIfAttributeIsSet) ValidateFloat64(ctx context.Context, req validator.Float64Request, resp *validator.Float64Response) {
+	validateReq := NullIfAttributeIsSetRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &NullIfAttributeIsSetResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av NullIfAttributeIsSet) ValidateInt64(ctx context.Context, req validator.Int64Request, resp *validator.Int64Response) {
+	validateReq := NullIfAttributeIsSetRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &NullIfAttributeIsSetResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av NullIfAttributeIsSet) ValidateList(ctx context.Context, req validator.ListRequest, resp *validator.ListResponse) {
+	validateReq := NullIfAttributeIsSetRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &NullIfAttributeIsSetResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av NullIfAttributeIsSet) ValidateMap(ctx context.Context, req validator.MapRequest, resp *validator.MapResponse) {
+	validateReq := NullIfAttributeIsSetRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &NullIfAttributeIsSetResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av NullIfAttributeIsSet) ValidateNumber(ctx context.Context, req validator.NumberRequest, resp *validator.NumberResponse) {
+	validateReq := NullIfAttributeIsSetRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &NullIfAttributeIsSetResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av NullIfAttributeIsSet) ValidateObject(ctx context.Context, req validator.ObjectRequest, resp *validator.ObjectResponse) {
+	validateReq := NullIfAttributeIsSetRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &NullIfAttributeIsSetResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av NullIfAttributeIsSet) ValidateSet(ctx context.Context, req validator.SetRequest, resp *validator.SetResponse) {
+	validateReq := NullIfAttributeIsSetRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &NullIfAttributeIsSetResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av NullIfAttributeIsSet) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	validateReq := NullIfAttributeIsSetRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &NullIfAttributeIsSetResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}

--- a/internal/null_if_attribute_is_set_test.go
+++ b/internal/null_if_attribute_is_set_test.go
@@ -1,0 +1,318 @@
+package internal_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
+	"github.com/FrangipaneTeam/terraform-plugin-framework-validators/internal"
+)
+
+func TestNullIfAttributeIsSetOneOfValidator(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		req             internal.NullIfAttributeIsSetRequest
+		in              path.Expression
+		inPath          path.Path
+		expError        bool
+		expErrorMessage string
+	}
+
+	testCases := map[string]testCase{
+		"baseString": {
+			req: internal.NullIfAttributeIsSetRequest{
+				ConfigValue:    types.StringValue("value"),
+				Path:           path.Root("bar"),
+				PathExpression: path.MatchRoot("bar"),
+				Config: tfsdk.Config{
+					Schema: schema.Schema{
+						Attributes: map[string]schema.Attribute{
+							"foo": schema.StringAttribute{},
+							"bar": schema.StringAttribute{},
+						},
+					},
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"foo": tftypes.String,
+							"bar": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"foo": tftypes.NewValue(tftypes.String, "excepted value"),
+						"bar": tftypes.NewValue(tftypes.String, "value"),
+					}),
+				},
+			},
+			in:              path.MatchRoot("foo"),
+			inPath:          path.Root("foo"),
+			expError:        true,
+			expErrorMessage: "If foo attribute is set this attribute is NULL",
+		},
+		"extendedString": {
+			req: internal.NullIfAttributeIsSetRequest{
+				ConfigValue:    types.StringValue("bar value"),
+				Path:           path.Root("foobar").AtListIndex(0).AtName("bar2"),
+				PathExpression: path.MatchRoot("foobar").AtListIndex(0).AtName("bar2"),
+				Config: tfsdk.Config{
+					Schema: schema.Schema{
+						Attributes: map[string]schema.Attribute{
+							"foo": schema.StringAttribute{},
+							"bar": schema.StringAttribute{},
+							"foobar": schema.ListNestedAttribute{
+								NestedObject: schema.NestedAttributeObject{
+									Attributes: map[string]schema.Attribute{
+										"bar1": schema.StringAttribute{},
+										"bar2": schema.StringAttribute{},
+									},
+								},
+							},
+						},
+					},
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"foo": tftypes.String,
+							"bar": tftypes.String,
+							"foobar": tftypes.List{
+								ElementType: tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"bar1": tftypes.String,
+										"bar2": tftypes.String,
+									},
+								},
+							},
+						},
+					}, map[string]tftypes.Value{
+						"foo": tftypes.NewValue(tftypes.String, "excepted value"),
+						"bar": tftypes.NewValue(tftypes.String, "bar value"),
+						"foobar": tftypes.NewValue(tftypes.List{
+							ElementType: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"bar1": tftypes.String,
+									"bar2": tftypes.String,
+								},
+							},
+						}, []tftypes.Value{
+							tftypes.NewValue(tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"bar1": tftypes.String,
+									"bar2": tftypes.String,
+								},
+							}, map[string]tftypes.Value{
+								"bar1": tftypes.NewValue(tftypes.String, "bar1 excepted value"),
+								"bar2": tftypes.NewValue(tftypes.String, attr.NullValueString),
+							}),
+						},
+						),
+					}),
+				},
+			},
+			in:              path.MatchRoot("foobar").AtListIndex(0).AtName("bar1"),
+			inPath:          path.Root("foobar").AtListIndex(0).AtName("bar1"),
+			expError:        true,
+			expErrorMessage: "If foobar[0].bar1 attribute is set this attribute is NULL",
+		},
+		"baseInt64": {
+			req: internal.NullIfAttributeIsSetRequest{
+				ConfigValue:    types.StringValue("bar value"),
+				Path:           path.Root("bar"),
+				PathExpression: path.MatchRoot("bar"),
+				Config: tfsdk.Config{
+					Schema: schema.Schema{
+						Attributes: map[string]schema.Attribute{
+							"foo": schema.Int64Attribute{},
+							"bar": schema.StringAttribute{},
+						},
+					},
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"foo": tftypes.Number,
+							"bar": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"foo": tftypes.NewValue(tftypes.Number, int64(10)),
+						"bar": tftypes.NewValue(tftypes.String, attr.NullValueString),
+					}),
+				},
+			},
+			in:              path.MatchRoot("foo"),
+			inPath:          path.Root("foo"),
+			expError:        true,
+			expErrorMessage: "If foo attribute is set this attribute is NULL",
+		},
+		"baseBool": {
+			req: internal.NullIfAttributeIsSetRequest{
+				ConfigValue:    types.StringValue("bar value"),
+				Path:           path.Root("bar"),
+				PathExpression: path.MatchRoot("bar"),
+				Config: tfsdk.Config{
+					Schema: schema.Schema{
+						Attributes: map[string]schema.Attribute{
+							"foo": schema.BoolAttribute{},
+							"bar": schema.StringAttribute{},
+						},
+					},
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"foo": tftypes.Bool,
+							"bar": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"foo": tftypes.NewValue(tftypes.Bool, true),
+						"bar": tftypes.NewValue(tftypes.String, attr.NullValueString),
+					}),
+				},
+			},
+			in:              path.MatchRoot("foo"),
+			inPath:          path.Root("foo"),
+			expError:        true,
+			expErrorMessage: "If foo attribute is set this attribute is NULL",
+		},
+		"path-attribute-is-null": {
+			req: internal.NullIfAttributeIsSetRequest{
+				ConfigValue:    types.StringNull(),
+				Path:           path.Root("bar"),
+				PathExpression: path.MatchRoot("bar"),
+				Config: tfsdk.Config{
+					Schema: schema.Schema{
+						Attributes: map[string]schema.Attribute{
+							"foo": schema.StringAttribute{},
+							"bar": schema.StringAttribute{},
+						},
+					},
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"foo": tftypes.String,
+							"bar": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"foo": tftypes.NewValue(tftypes.String, attr.NullValueString),
+						"bar": tftypes.NewValue(tftypes.String, attr.NullValueString),
+					}),
+				},
+			},
+			in:       path.MatchRoot("foo"),
+			inPath:   path.Root("foo"),
+			expError: false,
+		},
+		"config-attribute-is-null": {
+			req: internal.NullIfAttributeIsSetRequest{
+				ConfigValue:    types.StringNull(),
+				Path:           path.Root("bar"),
+				PathExpression: path.MatchRoot("bar"),
+				Config: tfsdk.Config{
+					Schema: schema.Schema{
+						Attributes: map[string]schema.Attribute{
+							"foo": schema.StringAttribute{},
+							"bar": schema.StringAttribute{},
+						},
+					},
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"foo": tftypes.String,
+							"bar": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"foo": tftypes.NewValue(tftypes.String, "excepted value"),
+						"bar": tftypes.NewValue(tftypes.String, "bar value"),
+					}),
+				},
+			},
+			in:       path.MatchRoot("foo"),
+			inPath:   path.Root("foo"),
+			expError: false,
+		},
+		"config-attribute-is-null-and-path-attribute-not-match": {
+			req: internal.NullIfAttributeIsSetRequest{
+				ConfigValue:    types.StringNull(),
+				Path:           path.Root("bar"),
+				PathExpression: path.MatchRoot("bar"),
+				Config: tfsdk.Config{
+					Schema: schema.Schema{
+						Attributes: map[string]schema.Attribute{
+							"foo": schema.StringAttribute{},
+							"bar": schema.StringAttribute{},
+						},
+					},
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"foo": tftypes.String,
+							"bar": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"foo": tftypes.NewValue(tftypes.String, "excepted value"),
+						"bar": tftypes.NewValue(tftypes.String, attr.NullValueString),
+					}),
+				},
+			},
+			in:       path.MatchRoot("foo"),
+			inPath:   path.Root("foo"),
+			expError: false,
+		},
+		"unknown": {
+			req: internal.NullIfAttributeIsSetRequest{
+				ConfigValue:    types.StringUnknown(),
+				Path:           path.Root("bar"),
+				PathExpression: path.MatchRoot("bar"),
+				Config: tfsdk.Config{
+					Schema: schema.Schema{
+						Attributes: map[string]schema.Attribute{
+							"foo": schema.StringAttribute{},
+							"bar": schema.StringAttribute{},
+						},
+					},
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"foo": tftypes.String,
+							"bar": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"foo": tftypes.NewValue(tftypes.String, "excepted value"),
+						"bar": tftypes.NewValue(tftypes.String, attr.UnknownValueString),
+					}),
+				},
+			},
+			in:              path.MatchRoot("foo"),
+			inPath:          path.Root("foo"),
+			expError:        true,
+			expErrorMessage: "If foo attribute is set this attribute is NULL",
+		},
+	}
+
+	for name, test := range testCases {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			res := &internal.NullIfAttributeIsSetResponse{}
+
+			internal.NullIfAttributeIsSet{
+				PathExpression: test.in,
+			}.Validate(context.TODO(), test.req, res)
+
+			if test.expError && res.Diagnostics.HasError() {
+				if !res.Diagnostics.Contains(diag.NewAttributeErrorDiagnostic(
+					test.inPath,
+					fmt.Sprintf("Invalid configuration for attribute %s", test.req.Path),
+					test.expErrorMessage,
+				)) {
+					t.Fatal(fmt.Sprintf("expected error(s) to contain (%s), got none. Error message is : (%s)", test.expErrorMessage, res.Diagnostics.Errors())) //nolint:gosimple
+				}
+			}
+
+			if !test.expError && res.Diagnostics.HasError() {
+				t.Fatalf("unexpected error(s): %s", res.Diagnostics)
+			}
+
+			if test.expError && !res.Diagnostics.HasError() {
+				t.Fatal("expected error(s), got none")
+			}
+		})
+	}
+}

--- a/listvalidator/null_if_attribute_is_set.go
+++ b/listvalidator/null_if_attribute_is_set.go
@@ -1,0 +1,16 @@
+package listvalidator
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/FrangipaneTeam/terraform-plugin-framework-validators/internal"
+)
+
+// NullIfAttributeIsSet checks if the path.Path attribute contains
+// one of the exceptedValue attr.Value.
+func NullIfAttributeIsSet(path path.Expression) validator.List {
+	return internal.NullIfAttributeIsSet{
+		PathExpression: path,
+	}
+}

--- a/mapvalidator/null_if_attribute_is_set.go
+++ b/mapvalidator/null_if_attribute_is_set.go
@@ -1,0 +1,16 @@
+package mapvalidator
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/FrangipaneTeam/terraform-plugin-framework-validators/internal"
+)
+
+// NullIfAttributeIsSet checks if the path.Path attribute contains
+// one of the exceptedValue attr.Value.
+func NullIfAttributeIsSet(path path.Expression) validator.Map {
+	return internal.NullIfAttributeIsSet{
+		PathExpression: path,
+	}
+}

--- a/setvalidator/null_if_attribute_is_set.go
+++ b/setvalidator/null_if_attribute_is_set.go
@@ -1,0 +1,16 @@
+package setvalidator
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/FrangipaneTeam/terraform-plugin-framework-validators/internal"
+)
+
+// NullIfAttributeIsSet checks if the path.Path attribute contains
+// one of the exceptedValue attr.Value.
+func NullIfAttributeIsSet(path path.Expression) validator.Set {
+	return internal.NullIfAttributeIsSet{
+		PathExpression: path,
+	}
+}

--- a/stringvalidator/null_if_attribute_is_set.go
+++ b/stringvalidator/null_if_attribute_is_set.go
@@ -1,0 +1,16 @@
+package stringvalidator
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/FrangipaneTeam/terraform-plugin-framework-validators/internal"
+)
+
+// NullIfAttributeIsSet checks if the path.Path attribute contains
+// one of the exceptedValue attr.Value.
+func NullIfAttributeIsSet(path path.Expression) validator.String {
+	return internal.NullIfAttributeIsSet{
+		PathExpression: path,
+	}
+}


### PR DESCRIPTION
New validator that allows you to validate that a attribute is null if another attribute is set. 
This is available for all types of attributes.

**Usage** 

```go
// Schema defines the schema for the resource.
func (r *xResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
    resp.Schema = schema.Schema{
        (...)
            "network_type": schema.StringAttribute{
                Optional:            true,
                MarkdownDescription: "Network type ...",
                Validators: []validator.String{
                    fstringvalidator.OneOf("public", "private"),
                },
            },
            "enabled": schema.BoolAttribute{
                Optional:            true,
                MarkdownDescription: "Enable ...",
                Validators: []validator.Bool{
                    fboolvalidator.NullIfAttributeIsSet(path.MatchRoot("network_type"))
                },
            },
```

