### PR TITLE
feat: add generic validator `RequireIfAttributeIsSet`

### DIFF
--- a/.changelog/84.txt
+++ b/.changelog/84.txt
@@ -1,3 +1,3 @@
 ```release-note:feature
-`RequireIfAttributeIsSet` - New validator that allows you to validate that a attribute is required if another attribute is set. This is available for all types of attributes.
+`RequireIfAttributeIsSet` - New validator that allows you to validate that an attribute is required if another attribute is set. This is available for all types of attributes.
 ```

--- a/.changelog/84.txt
+++ b/.changelog/84.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+`RequireIfAttributeIsSet` - New validator that allows you to validate that a attribute is required if another attribute is set. This is available for all types of attributes.
+```

--- a/boolvalidator/require_if_attribute_is_set.go
+++ b/boolvalidator/require_if_attribute_is_set.go
@@ -1,0 +1,15 @@
+package boolvalidator
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/FrangipaneTeam/terraform-plugin-framework-validators/internal"
+)
+
+// RequireIfAttributeIsSet checks if the path.Path attribute is set
+func RequireIfAttributeIsSet(path path.Expression) validator.Bool {
+	return internal.RequireIfAttributeIsSet{
+		PathExpression: path,
+	}
+}

--- a/docs/boolvalidator/index.md
+++ b/docs/boolvalidator/index.md
@@ -14,6 +14,7 @@ import (
 ## List of Validators
 
 - [`RequireIfAttributeIsOneOf`](../common/require_if_attribute_is_one_of.md) - This validator is used to require the attribute if another attribute is one of the given values.
+- [`RequireIfAttributeIsSet`](../common/require_if_attribute_is_set.md) - This validator is used to require the attribute if another attribute is set.
 - [`NullIfAttributeIsOneOf`](../common/null_if_attribute_is_one_of.md) - This validator is used to verify the attribute value is null if another attribute is one of the given values.
 
 ## Special

--- a/docs/common/require_if_attribute_is_set.md
+++ b/docs/common/require_if_attribute_is_set.md
@@ -1,0 +1,33 @@
+# `RequireIfAttributeIsSet`
+
+!!! quote inline end "Released in v1.8.0"
+
+This validator is used to require the attribute if another attribute is set.
+Set could mean either the attribute is present in the configuration.
+
+## How to use it
+
+```go
+// Schema defines the schema for the resource.
+func (r *xResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+    resp.Schema = schema.Schema{
+        (...)
+            "network_type": schema.StringAttribute{
+                Optional:            true,
+                MarkdownDescription: "Network type ...",
+                Validators: []validator.String{
+                    fstringvalidator.OneOf("public", "private"),
+                },
+            },
+            "enabled": schema.BoolAttribute{
+                Optional:            true,
+                MarkdownDescription: "Enable ...",
+                Validators: []validator.String{
+                    fboolvalidator.RequireIfAttributeIsSet(path.MatchRoot("network_type"))
+                },
+            },
+```
+
+## Example of generated documentation
+
+If the value of [`network_type`](#network_type) attribute is set this attribute is **REQUIRED**.

--- a/docs/int64validator/index.md
+++ b/docs/int64validator/index.md
@@ -14,6 +14,7 @@ import (
 ## List of Validators
 
 - [`RequireIfAttributeIsOneOf`](../common/require_if_attribute_is_one_of.md) - This validator is used to require the attribute if another attribute is one of the given values.
+- [`RequireIfAttributeIsSet`](../common/require_if_attribute_is_set.md) - This validator is used to require the attribute if another attribute is set.
 - [`NullIfAttributeIsOneOf`](../common/null_if_attribute_is_one_of.md) - This validator is used to verify the attribute value is null if another attribute is one of the given values.
 - [`OneOfWithDescription`](oneofwithdescription.md) - This validator is used to check if the string is one of the given values and format the description and the markdown description.
 - [`AttributeIsDivisibleByAnInteger`](attribute_is_divisible_by_an_integer.md) - This validator is used to validate that the attribute is divisible by an integer.

--- a/docs/listvalidator/index.md
+++ b/docs/listvalidator/index.md
@@ -16,6 +16,7 @@ import (
 Every `string` validators are available for maps thanks to a generic validator provided by Hashicorp. See the section below for more details.
 
 - [`RequireIfAttributeIsOneOf`](../common/require_if_attribute_is_one_of.md) - This validator is used to require the attribute if another attribute is one of the given values.
+- [`RequireIfAttributeIsSet`](../common/require_if_attribute_is_set.md) - This validator is used to require the attribute if another attribute is set.
 - [`NullIfAttributeIsOneOf`](../common/null_if_attribute_is_one_of.md) - This validator is used to verify the attribute value is null if another attribute is one of the given values.
 
 ## Special

--- a/docs/mapvalidator/index.md
+++ b/docs/mapvalidator/index.md
@@ -16,6 +16,7 @@ import (
 Every `string` validators are available for maps thanks to a generic validator provided by Hashicorp. See the section below for more details.
 
 - [`RequireIfAttributeIsOneOf`](../common/require_if_attribute_is_one_of.md) - This validator is used to require the attribute if another attribute is one of the given values.
+- [`RequireIfAttributeIsSet`](../common/require_if_attribute_is_set.md) - This validator is used to require the attribute if another attribute is set.
 - [`NullIfAttributeIsOneOf`](../common/null_if_attribute_is_one_of.md) - This validator is used to verify the attribute value is null if another attribute is one of the given values.
 
 ## Special

--- a/docs/setvalidator/index.md
+++ b/docs/setvalidator/index.md
@@ -16,6 +16,7 @@ import (
 Every `string` validators are available for maps thanks to a generic validator provided by Hashicorp. See the section below for more details.
 
 - [`RequireIfAttributeIsOneOf`](../common/require_if_attribute_is_one_of.md) - This validator is used to require the attribute if another attribute is one of the given values.
+- [`RequireIfAttributeIsSet`](../common/require_if_attribute_is_set.md) - This validator is used to require the attribute if another attribute is set.
 - [`NullIfAttributeIsOneOf`](../common/null_if_attribute_is_one_of.md) - This validator is used to verify the attribute value is null if another attribute is one of the given values.
 
 ### Special

--- a/docs/stringvalidator/index.md
+++ b/docs/stringvalidator/index.md
@@ -14,6 +14,7 @@ import (
 ## List of Validators
 
 - [`RequireIfAttributeIsOneOf`](../common/require_if_attribute_is_one_of.md) - This validator is used to require the attribute if another attribute is one of the given values.
+- [`RequireIfAttributeIsSet`](../common/require_if_attribute_is_set.md) - This validator is used to require the attribute if another attribute is set.
 - [`NullIfAttributeIsOneOf`](../common/null_if_attribute_is_one_of.md) - This validator is used to verify the attribute value is null if another attribute is one of the given values.
 - [`OneOfWithDescription`](oneofwithdescription.md) - This validator is used to check if the string is one of the given values and format the description and the markdown description.
 

--- a/int64validator/require_if_attribute_is_set.go
+++ b/int64validator/require_if_attribute_is_set.go
@@ -1,0 +1,15 @@
+package int64validator
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/FrangipaneTeam/terraform-plugin-framework-validators/internal"
+)
+
+// RequireIfAttributeIsSet checks if the path.Path attribute is set
+func RequireIfAttributeIsSet(path path.Expression) validator.Int64 {
+	return internal.RequireIfAttributeIsSet{
+		PathExpression: path,
+	}
+}

--- a/internal/require_if_attribute_is_set.go
+++ b/internal/require_if_attribute_is_set.go
@@ -1,0 +1,226 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+)
+
+// This type of validator must satisfy all types.
+var (
+	_ validator.Bool    = RequireIfAttributeIsSet{}
+	_ validator.Float64 = RequireIfAttributeIsSet{}
+	_ validator.Int64   = RequireIfAttributeIsSet{}
+	_ validator.List    = RequireIfAttributeIsSet{}
+	_ validator.Map     = RequireIfAttributeIsSet{}
+	_ validator.Number  = RequireIfAttributeIsSet{}
+	_ validator.Object  = RequireIfAttributeIsSet{}
+	_ validator.Set     = RequireIfAttributeIsSet{}
+	_ validator.String  = RequireIfAttributeIsSet{}
+)
+
+// RequireIfAttributeIsSet is the underlying struct implementing AlsoRequires.
+type RequireIfAttributeIsSet struct {
+	PathExpression path.Expression
+}
+
+type RequireIfAttributeIsSetRequest struct {
+	Config         tfsdk.Config
+	ConfigValue    attr.Value
+	Path           path.Path
+	PathExpression path.Expression
+}
+
+type RequireIfAttributeIsSetResponse struct {
+	Diagnostics diag.Diagnostics
+}
+
+func (av RequireIfAttributeIsSet) Description(_ context.Context) string {
+	return fmt.Sprintf("If %s attribute is set this attribute is REQUIRED", av.PathExpression)
+}
+
+func (av RequireIfAttributeIsSet) MarkdownDescription(_ context.Context) string {
+	return fmt.Sprintf("If the [`%s`](#%s) attribute is set this attribute is **REQUIRED**", av.PathExpression, av.PathExpression)
+}
+
+func (av RequireIfAttributeIsSet) Validate(ctx context.Context, req RequireIfAttributeIsSetRequest, res *RequireIfAttributeIsSetResponse) {
+	var diags diag.Diagnostics
+
+	// If attribute configuration is not null, there is nothing else to validate
+	if !req.ConfigValue.IsNull() {
+		return
+	}
+
+	expression := req.PathExpression.Merge(av.PathExpression)
+
+	// Here attribute configuration is null, so we need to check if attribute in the path
+	// is equal to one of the excepted values
+	paths, diags := req.Config.PathMatches(ctx, expression)
+	res.Diagnostics.Append(diags...)
+	if res.Diagnostics.HasError() {
+		return
+	}
+
+	if len(paths) == 0 {
+		res.Diagnostics.AddError(
+			fmt.Sprintf("Invalid configuration for attribute %s", req.Path),
+			"Path must be set",
+		)
+		return
+	}
+
+	for _, path := range paths {
+		var mpVal attr.Value
+		diags = req.Config.GetAttribute(ctx, path, &mpVal)
+		if diags.HasError() {
+			res.Diagnostics.AddError(
+				fmt.Sprintf("Invalid configuration for attribute %s", req.Path),
+				fmt.Sprintf("Unable to retrieve attribute path: %q", path),
+			)
+			return
+		}
+
+		// If the attribute configuration is null, there is nothing else to validate
+		if mpVal.IsNull() {
+			return
+		}
+		if req.ConfigValue.IsNull() {
+			res.Diagnostics.AddAttributeError(
+				path,
+				fmt.Sprintf("Invalid configuration for attribute %s", req.Path),
+				av.Description(ctx),
+			)
+		}
+	}
+}
+
+func (av RequireIfAttributeIsSet) ValidateBool(ctx context.Context, req validator.BoolRequest, resp *validator.BoolResponse) {
+	validateReq := RequireIfAttributeIsSetRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &RequireIfAttributeIsSetResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av RequireIfAttributeIsSet) ValidateFloat64(ctx context.Context, req validator.Float64Request, resp *validator.Float64Response) {
+	validateReq := RequireIfAttributeIsSetRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &RequireIfAttributeIsSetResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av RequireIfAttributeIsSet) ValidateInt64(ctx context.Context, req validator.Int64Request, resp *validator.Int64Response) {
+	validateReq := RequireIfAttributeIsSetRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &RequireIfAttributeIsSetResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av RequireIfAttributeIsSet) ValidateList(ctx context.Context, req validator.ListRequest, resp *validator.ListResponse) {
+	validateReq := RequireIfAttributeIsSetRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &RequireIfAttributeIsSetResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av RequireIfAttributeIsSet) ValidateMap(ctx context.Context, req validator.MapRequest, resp *validator.MapResponse) {
+	validateReq := RequireIfAttributeIsSetRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &RequireIfAttributeIsSetResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av RequireIfAttributeIsSet) ValidateNumber(ctx context.Context, req validator.NumberRequest, resp *validator.NumberResponse) {
+	validateReq := RequireIfAttributeIsSetRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &RequireIfAttributeIsSetResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av RequireIfAttributeIsSet) ValidateObject(ctx context.Context, req validator.ObjectRequest, resp *validator.ObjectResponse) {
+	validateReq := RequireIfAttributeIsSetRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &RequireIfAttributeIsSetResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av RequireIfAttributeIsSet) ValidateSet(ctx context.Context, req validator.SetRequest, resp *validator.SetResponse) {
+	validateReq := RequireIfAttributeIsSetRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &RequireIfAttributeIsSetResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av RequireIfAttributeIsSet) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	validateReq := RequireIfAttributeIsSetRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	validateResp := &RequireIfAttributeIsSetResponse{}
+
+	av.Validate(ctx, validateReq, validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}

--- a/internal/require_if_attribute_is_set_test.go
+++ b/internal/require_if_attribute_is_set_test.go
@@ -1,0 +1,289 @@
+package internal_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
+	"github.com/FrangipaneTeam/terraform-plugin-framework-validators/internal"
+)
+
+func TestRequireIfAttributeIsSetValidator(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		req             internal.RequireIfAttributeIsSetRequest
+		in              path.Expression
+		inPath          path.Path
+		expError        bool
+		expErrorMessage string
+	}
+
+	testCases := map[string]testCase{
+		"baseString": {
+			req: internal.RequireIfAttributeIsSetRequest{
+				ConfigValue:    types.StringNull(),
+				Path:           path.Root("bar"),
+				PathExpression: path.MatchRoot("bar"),
+				Config: tfsdk.Config{
+					Schema: schema.Schema{
+						Attributes: map[string]schema.Attribute{
+							"foo": schema.StringAttribute{},
+							"bar": schema.StringAttribute{},
+						},
+					},
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"foo": tftypes.String,
+							"bar": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"foo": tftypes.NewValue(tftypes.String, "excepted value"),
+						"bar": tftypes.NewValue(tftypes.String, nil),
+					}),
+				},
+			},
+			in:              path.MatchRoot("foo"),
+			inPath:          path.Root("foo"),
+			expError:        true,
+			expErrorMessage: "If foo attribute is set this attribute is REQUIRED",
+		},
+		"extendedString": {
+			req: internal.RequireIfAttributeIsSetRequest{
+				ConfigValue:    types.StringNull(),
+				Path:           path.Root("foobar").AtListIndex(0).AtName("bar2"),
+				PathExpression: path.MatchRoot("foobar").AtListIndex(0).AtName("bar2"),
+				Config: tfsdk.Config{
+					Schema: schema.Schema{
+						Attributes: map[string]schema.Attribute{
+							"foo": schema.StringAttribute{},
+							"bar": schema.StringAttribute{},
+							"foobar": schema.ListNestedAttribute{
+								NestedObject: schema.NestedAttributeObject{
+									Attributes: map[string]schema.Attribute{
+										"bar1": schema.StringAttribute{},
+										"bar2": schema.StringAttribute{},
+									},
+								},
+							},
+						},
+					},
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"foo": tftypes.String,
+							"bar": tftypes.String,
+							"foobar": tftypes.List{
+								ElementType: tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"bar1": tftypes.String,
+										"bar2": tftypes.String,
+									},
+								},
+							},
+						},
+					}, map[string]tftypes.Value{
+						"foo": tftypes.NewValue(tftypes.String, "excepted value"),
+						"bar": tftypes.NewValue(tftypes.String, "bar value"),
+						"foobar": tftypes.NewValue(tftypes.List{
+							ElementType: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"bar1": tftypes.String,
+									"bar2": tftypes.String,
+								},
+							},
+						}, []tftypes.Value{
+							tftypes.NewValue(tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"bar1": tftypes.String,
+									"bar2": tftypes.String,
+								},
+							}, map[string]tftypes.Value{
+								"bar1": tftypes.NewValue(tftypes.String, "bar1 excepted value"),
+								"bar2": tftypes.NewValue(tftypes.String, nil),
+							}),
+						},
+						),
+					}),
+				},
+			},
+			in:              path.MatchRoot("foobar").AtListIndex(0).AtName("bar1"),
+			inPath:          path.Root("foobar").AtListIndex(0).AtName("bar1"),
+			expError:        true,
+			expErrorMessage: "If foobar[0].bar1 attribute is set this attribute is REQUIRED",
+		},
+		"baseInt64": {
+			req: internal.RequireIfAttributeIsSetRequest{
+				ConfigValue:    types.StringNull(),
+				Path:           path.Root("bar"),
+				PathExpression: path.MatchRoot("bar"),
+				Config: tfsdk.Config{
+					Schema: schema.Schema{
+						Attributes: map[string]schema.Attribute{
+							"foo": schema.Int64Attribute{},
+							"bar": schema.StringAttribute{},
+						},
+					},
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"foo": tftypes.Number,
+							"bar": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"foo": tftypes.NewValue(tftypes.Number, int64(10)),
+						"bar": tftypes.NewValue(tftypes.String, nil),
+					}),
+				},
+			},
+			in:              path.MatchRoot("foo"),
+			inPath:          path.Root("foo"),
+			expError:        true,
+			expErrorMessage: "If foo attribute is set this attribute is REQUIRED",
+		},
+		"baseBool": {
+			req: internal.RequireIfAttributeIsSetRequest{
+				ConfigValue:    types.StringNull(),
+				Path:           path.Root("bar"),
+				PathExpression: path.MatchRoot("bar"),
+				Config: tfsdk.Config{
+					Schema: schema.Schema{
+						Attributes: map[string]schema.Attribute{
+							"foo": schema.BoolAttribute{},
+							"bar": schema.StringAttribute{},
+						},
+					},
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"foo": tftypes.Bool,
+							"bar": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"foo": tftypes.NewValue(tftypes.Bool, true),
+						"bar": tftypes.NewValue(tftypes.String, nil),
+					}),
+				},
+			},
+			in:              path.MatchRoot("foo"),
+			inPath:          path.Root("foo"),
+			expError:        true,
+			expErrorMessage: "If foo attribute is set this attribute is REQUIRED",
+		},
+		"path-attribute-is-null": {
+			req: internal.RequireIfAttributeIsSetRequest{
+				ConfigValue:    types.StringNull(),
+				Path:           path.Root("bar"),
+				PathExpression: path.MatchRoot("bar"),
+				Config: tfsdk.Config{
+					Schema: schema.Schema{
+						Attributes: map[string]schema.Attribute{
+							"foo": schema.StringAttribute{},
+							"bar": schema.StringAttribute{},
+						},
+					},
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"foo": tftypes.String,
+							"bar": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"foo": tftypes.NewValue(tftypes.String, nil),
+						"bar": tftypes.NewValue(tftypes.String, nil),
+					}),
+				},
+			},
+			in:       path.MatchRoot("foo"),
+			inPath:   path.Root("foo"),
+			expError: false,
+		},
+		"config-attribute-is-set": {
+			req: internal.RequireIfAttributeIsSetRequest{
+				ConfigValue:    types.StringValue("excepted value"),
+				Path:           path.Root("bar"),
+				PathExpression: path.MatchRoot("bar"),
+				Config: tfsdk.Config{
+					Schema: schema.Schema{
+						Attributes: map[string]schema.Attribute{
+							"foo": schema.StringAttribute{},
+							"bar": schema.StringAttribute{},
+						},
+					},
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"foo": tftypes.String,
+							"bar": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"foo": tftypes.NewValue(tftypes.String, "excepted value"),
+						"bar": tftypes.NewValue(tftypes.String, "bar value"),
+					}),
+				},
+			},
+			in:       path.MatchRoot("foo"),
+			inPath:   path.Root("foo"),
+			expError: false,
+		},
+		"unknown": {
+			req: internal.RequireIfAttributeIsSetRequest{
+				ConfigValue:    types.StringUnknown(),
+				Path:           path.Root("bar"),
+				PathExpression: path.MatchRoot("bar"),
+				Config: tfsdk.Config{
+					Schema: schema.Schema{
+						Attributes: map[string]schema.Attribute{
+							"foo": schema.StringAttribute{},
+							"bar": schema.StringAttribute{},
+						},
+					},
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"foo": tftypes.String,
+							"bar": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"foo": tftypes.NewValue(tftypes.String, "excepted value"),
+						"bar": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+					}),
+				},
+			},
+			in:       path.MatchRoot("foo"),
+			inPath:   path.Root("foo"),
+			expError: false,
+		},
+	}
+
+	for name, test := range testCases {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			res := &internal.RequireIfAttributeIsSetResponse{}
+
+			internal.RequireIfAttributeIsSet{
+				PathExpression: test.in,
+			}.Validate(context.TODO(), test.req, res)
+
+			if test.expError && res.Diagnostics.HasError() {
+				if !res.Diagnostics.Contains(diag.NewAttributeErrorDiagnostic(
+					test.inPath,
+					fmt.Sprintf("Invalid configuration for attribute %s", test.req.Path),
+					test.expErrorMessage,
+				)) {
+					t.Fatal(fmt.Sprintf("expected error(s) to contain (%s), got none. Error message is : (%s)", test.expErrorMessage, res.Diagnostics.Errors())) //nolint:gosimple
+				}
+			}
+
+			if !test.expError && res.Diagnostics.HasError() {
+				t.Fatalf("unexpected error(s): %s", res.Diagnostics)
+			}
+
+			if test.expError && !res.Diagnostics.HasError() {
+				t.Fatal("expected error(s), got none")
+			}
+		})
+	}
+}

--- a/listvalidator/require_if_attribute_is_set.go
+++ b/listvalidator/require_if_attribute_is_set.go
@@ -1,0 +1,16 @@
+package listvalidator
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/FrangipaneTeam/terraform-plugin-framework-validators/internal"
+)
+
+// RequireIfAttributeIsSet checks if the path.Path attribute is set
+
+func RequireIfAttributeIsSet(path path.Expression) validator.List {
+	return internal.RequireIfAttributeIsSet{
+		PathExpression: path,
+	}
+}

--- a/mapvalidator/require_if_attribute_is_set.go
+++ b/mapvalidator/require_if_attribute_is_set.go
@@ -1,0 +1,15 @@
+package mapvalidator
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/FrangipaneTeam/terraform-plugin-framework-validators/internal"
+)
+
+// RequireIfAttributeIsSet checks if the path.Path attribute is set
+func RequireIfAttributeIsSet(path path.Expression) validator.Map {
+	return internal.RequireIfAttributeIsSet{
+		PathExpression: path,
+	}
+}

--- a/setvalidator/require_if_attribute_is_set.go
+++ b/setvalidator/require_if_attribute_is_set.go
@@ -1,0 +1,15 @@
+package setvalidator
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/FrangipaneTeam/terraform-plugin-framework-validators/internal"
+)
+
+// RequireIfAttributeIsSet checks if the path.Path attribute is set
+func RequireIfAttributeIsSet(path path.Expression) validator.Set {
+	return internal.RequireIfAttributeIsSet{
+		PathExpression: path,
+	}
+}

--- a/stringvalidator/require_if_attribute_is_set.go
+++ b/stringvalidator/require_if_attribute_is_set.go
@@ -1,0 +1,15 @@
+package stringvalidator
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/FrangipaneTeam/terraform-plugin-framework-validators/internal"
+)
+
+// RequireIfAttributeIsSet checks if the path.Path attribute is set
+func RequireIfAttributeIsSet(path path.Expression) validator.String {
+	return internal.RequireIfAttributeIsSet{
+		PathExpression: path,
+	}
+}


### PR DESCRIPTION
New validator that allows you to validate that a attribute is required if another attribute is set. This is available for all types of attributes.

**Usage**


```go
// Schema defines the schema for the resource.
func (r *xResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
    resp.Schema = schema.Schema{
        (...)
            "network_type": schema.StringAttribute{
                Optional:            true,
                MarkdownDescription: "Network type ...",
                Validators: []validator.String{
                    fstringvalidator.OneOf("public", "private"),
                },
            },
            "enabled": schema.BoolAttribute{
                Optional:            true,
                MarkdownDescription: "Enable ...",
                Validators: []validator.String{
                    fboolvalidator.RequireIfAttributeIsSet(path.MatchRoot("network_type"))
                },
            },
```